### PR TITLE
Migrate feed.aesthetic.computer from Cloudflare Worker to silo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "feed/dp1-feed"]
 	path = feed/dp1-feed
-	url = https://github.com/feral-file/dp1-feed.git
+	url = https://github.com/whistlegraph/dp1-feed.git

--- a/feed/build-feed.fish
+++ b/feed/build-feed.fish
@@ -12,9 +12,11 @@ set vault_env /workspaces/aesthetic-computer/aesthetic-computer-vault/feed/.env
 
 if test -f $vault_env
     echo "📦 Loading secrets from vault..."
-    # Export environment variables for fish
+    # Export environment variables for fish (split on first = only, strip quotes)
     for line in (cat $vault_env | grep -v '^#' | grep '=')
-        set -gx (string split '=' $line)
+        set -l parts (string split -m1 '=' $line)
+        set -l val (string trim -c '"' $parts[2])
+        set -gx $parts[1] $val
     end
     echo "✅ Secrets loaded"
     echo ""

--- a/feed/build-kidlisp-feed.mjs
+++ b/feed/build-kidlisp-feed.mjs
@@ -20,7 +20,7 @@ const execAsync = promisify(exec);
 
 const FEED_API_URL = 'https://feed.aesthetic.computer/api/v1';
 const API_SECRET = process.env.FEED_API_SECRET || 'YOUR_FEED_API_SECRET_HERE';
-const KIDLISP_CHANNEL_ID = '23b63744-649f-4274-add5-d1b439984e51';
+const KIDLISP_CHANNEL_ID = process.env.KIDLISP_CHANNEL_ID || '156c4235-4b24-4001-bec9-61ce0ac7c25e';
 
 // Keep track of playlist IDs we want to preserve
 let keepPlaylistIds = new Set();

--- a/feed/channel-config.json
+++ b/feed/channel-config.json
@@ -1,43 +1,66 @@
 {
   "channel": {
-    "id": "23b63744-649f-4274-add5-d1b439984e51",
-    "slug": "kidlisp-4212",
+    "id": "156c4235-4b24-4001-bec9-61ce0ac7c25e",
+    "slug": "kidlisp-7108",
     "title": "KidLisp",
     "curator": "prompt.ac",
     "summary": "KidLisp is a TV friendly programming language for kids of all ages! Developed by @jeffrey of Aesthetic Computer.",
-    "created": "2025-10-06T04:32:10.521Z",
-    "url": "https://feed.aesthetic.computer/api/v1/channels/23b63744-649f-4274-add5-d1b439984e51"
+    "created": "2026-02-20T06:45:44.127Z",
+    "url": "https://feed.aesthetic.computer/api/v1/channels/156c4235-4b24-4001-bec9-61ce0ac7c25e"
   },
   "playlists": [
     {
-      "id": "f60493a2-9e69-4e6b-837e-76047f48438c",
-      "title": "Top 100 as of Monday, October 6, 2025",
-      "description": "Top 100 most-hit KidLisp pieces from MongoDB aesthetic database",
+      "slot": 0,
+      "type": "dynamic",
+      "title": "Top 100",
+      "description": "Top 100 most-hit KidLisp pieces from MongoDB (all authors)",
       "items": 100,
-      "url": "https://feed.aesthetic.computer/api/v1/playlists/f60493a2-9e69-4e6b-837e-76047f48438c",
-      "generator": "create-top-kidlisp-playlist.mjs"
+      "generator": "silo-update-top100.mjs (handle: null)"
     },
     {
-      "id": "2680b102-04ee-47b5-b7d7-f814094695e7",
+      "slot": 1,
+      "type": "dynamic",
+      "title": "Top @jeffrey",
+      "description": "Top 100 most-hit KidLisp pieces by @jeffrey",
+      "items": 100,
+      "generator": "silo-update-top100.mjs (handle: jeffrey)"
+    },
+    {
+      "slot": 2,
+      "type": "dynamic",
+      "title": "Top @fifi",
+      "description": "Top 100 most-hit KidLisp pieces by @fifi",
+      "items": 100,
+      "generator": "silo-update-top100.mjs (handle: fifi)"
+    },
+    {
+      "slot": 3,
+      "type": "static",
+      "id": "a590114b-2e51-4eed-93d2-3601e0c50e46",
       "title": "Colors",
       "description": "151 CSS color names as solid color displays",
       "items": 151,
-      "url": "https://feed.aesthetic.computer/api/v1/playlists/2680b102-04ee-47b5-b7d7-f814094695e7",
+      "url": "https://feed.aesthetic.computer/api/v1/playlists/a590114b-2e51-4eed-93d2-3601e0c50e46",
       "generator": "create-kidlisp-colors-playlist.mjs"
     },
     {
-      "id": "e1bf1aae-2427-4dd0-a39d-f5da89fdf02e",
+      "slot": 4,
+      "type": "static",
+      "id": "ea5e26c9-e755-4f88-807e-c68a91cff49a",
       "title": "Chords for `clock`",
       "description": "31 Western musical chords using the clock piece with notepat notation",
       "items": 31,
-      "url": "https://feed.aesthetic.computer/api/v1/playlists/e1bf1aae-2427-4dd0-a39d-f5da89fdf02e",
+      "url": "https://feed.aesthetic.computer/api/v1/playlists/ea5e26c9-e755-4f88-807e-c68a91cff49a",
       "generator": "create-kidlisp-chords-playlist.mjs"
     }
   ],
   "metadata": {
-    "lastUpdated": "2025-10-06",
-    "totalItems": 282,
-    "tvParams": "?tv=true&density=5",
-    "dpVersion": "1.0.0"
+    "lastUpdated": "2026-02-20",
+    "totalItems": 482,
+    "backend": "sqlite (silo.aesthetic.computer)",
+    "dpVersion": "1.1.0",
+    "dynamicSlots": 3,
+    "staticSlots": 2,
+    "updateSchedule": "daily at 06:00 UTC"
   }
 }

--- a/feed/deploy-silo.fish
+++ b/feed/deploy-silo.fish
@@ -1,0 +1,160 @@
+#!/usr/bin/env fish
+# Deploy dp1-feed (SQLite mode) to silo.aesthetic.computer
+#
+# Usage:
+#   fish deploy-silo.fish          # Full deploy (build, upload, restart)
+#   fish deploy-silo.fish --setup  # First-time setup (create dirs, systemd service, env)
+
+set RED '\033[0;31m'
+set GREEN '\033[0;32m'
+set YELLOW '\033[1;33m'
+set NC '\033[0m'
+
+set SCRIPT_DIR (dirname (status --current-filename))
+set VAULT_DIR "$SCRIPT_DIR/../aesthetic-computer-vault"
+set SSH_KEY "$VAULT_DIR/home/.ssh/id_rsa"
+set SILO_HOST "silo.aesthetic.computer"
+set SILO_USER "root"
+set REMOTE_DIR "/opt/dp1-feed"
+set DP1_DIR "$SCRIPT_DIR/dp1-feed"
+
+set SETUP false
+if contains -- --setup $argv
+    set SETUP true
+end
+
+# Check for SSH key
+if not test -f $SSH_KEY
+    echo -e "$RED x SSH key not found: $SSH_KEY$NC"
+    exit 1
+end
+
+# Test SSH connection
+echo -e "$GREEN-> Testing SSH connection to $SILO_HOST...$NC"
+if not ssh -i $SSH_KEY -o StrictHostKeyChecking=no -o ConnectTimeout=10 $SILO_USER@$SILO_HOST "echo ok" &>/dev/null
+    echo -e "$RED x Cannot connect to $SILO_HOST$NC"
+    exit 1
+end
+echo -e "$GREEN   Connected.$NC"
+
+if test $SETUP = true
+    # First-time setup: create dirs, systemd service, generate keys
+    echo -e "$GREEN-> First-time setup on $SILO_HOST...$NC"
+
+    ssh -i $SSH_KEY $SILO_USER@$SILO_HOST "
+        # Create app directory and user
+        mkdir -p $REMOTE_DIR/data
+        id -u dp1feed &>/dev/null || useradd -r -s /bin/false dp1feed
+        chown -R dp1feed:dp1feed $REMOTE_DIR
+
+        # Install Node.js 22 if not present
+        if ! command -v node &>/dev/null || [ \$(node -v | cut -d. -f1 | tr -d v) -lt 22 ]; then
+            curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+            apt-get install -y nodejs
+        fi
+        echo 'Node:' \$(node -v)
+
+        # Install build tools for better-sqlite3
+        apt-get install -y python3 make g++ 2>/dev/null
+
+        # Create systemd service
+        cat > /etc/systemd/system/dp1-feed.service << 'UNIT'
+[Unit]
+Description=DP-1 Feed Operator API (SQLite)
+After=network.target
+
+[Service]
+Type=simple
+User=dp1feed
+WorkingDirectory=/opt/dp1-feed
+ExecStart=/usr/bin/node dist/server-sqlite.js
+EnvironmentFile=/opt/dp1-feed/.env
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+        systemctl daemon-reload
+        systemctl enable dp1-feed
+        echo 'Systemd service created and enabled.'
+    "
+
+    # Read API secret from vault (shared with silo dashboard)
+    echo -e "$GREEN-> Generating .env...$NC"
+    set VAULT_FEED_ENV "$VAULT_DIR/feed/.env"
+    if test -f $VAULT_FEED_ENV
+        set API_SECRET (grep '^FEED_API_SECRET=' $VAULT_FEED_ENV | sed 's/^FEED_API_SECRET=//')
+    end
+    if test -z "$API_SECRET"
+        set API_SECRET (openssl rand -hex 32)
+        echo -e "$YELLOW   No vault secret found, generated random API_SECRET$NC"
+    end
+    set ED25519_KEY (node -e "
+        const { generateKeyPairSync } = require('crypto');
+        const kp = generateKeyPairSync('ed25519');
+        const der = kp.privateKey.export({ type: 'pkcs8', format: 'der' });
+        console.log(Buffer.from(der).toString('hex'));
+    " 2>/dev/null; or echo "302e020100300506032b6570042204205e42cad90e34efb36d84b8dbbcf15777ac33f4126a80c087cdedfb030138ac6f")
+
+    ssh -i $SSH_KEY $SILO_USER@$SILO_HOST "cat > $REMOTE_DIR/.env << EOF
+API_SECRET=$API_SECRET
+ED25519_PRIVATE_KEY=$ED25519_KEY
+SQLITE_DB_PATH=/opt/dp1-feed/data/dp1-feed.db
+ENVIRONMENT=sqlite
+SELF_HOSTED_DOMAINS=silo.aesthetic.computer:8787,localhost:8787
+PORT=8787
+EOF
+    chown dp1feed:dp1feed $REMOTE_DIR/.env
+    chmod 600 $REMOTE_DIR/.env"
+
+    echo -e "$GREEN   Setup complete. Run 'fish deploy-silo.fish' to deploy.$NC"
+    exit 0
+end
+
+# Regular deploy: build locally, upload, restart
+echo -e "$GREEN-> Building dp1-feed (SQLite)...$NC"
+cd $DP1_DIR
+npm run sqlite:build 2>&1 | tail -1
+
+if test $status -ne 0
+    echo -e "$RED x Build failed$NC"
+    exit 1
+end
+
+echo -e "$GREEN-> Uploading to $SILO_HOST...$NC"
+ssh -i $SSH_KEY -o StrictHostKeyChecking=no $SILO_USER@$SILO_HOST "mkdir -p $REMOTE_DIR/dist"
+scp -i $SSH_KEY -o StrictHostKeyChecking=no \
+    $DP1_DIR/dist/server-sqlite.js \
+    $SILO_USER@$SILO_HOST:$REMOTE_DIR/dist/
+scp -i $SSH_KEY -o StrictHostKeyChecking=no \
+    $DP1_DIR/package.json \
+    $DP1_DIR/package-lock.json \
+    $SILO_USER@$SILO_HOST:$REMOTE_DIR/
+
+echo -e "$GREEN-> Installing dependencies & restarting...$NC"
+ssh -i $SSH_KEY $SILO_USER@$SILO_HOST "
+    chown -R dp1feed:dp1feed $REMOTE_DIR
+    cd $REMOTE_DIR && npm install --production --silent 2>&1 | tail -1
+    systemctl restart dp1-feed
+    sleep 2
+    systemctl is-active dp1-feed
+"
+
+set STATUS $status
+if test $STATUS -eq 0
+    echo -e "$GREEN   dp1-feed is running.$NC"
+
+    # Quick health check
+    sleep 1
+    ssh -i $SSH_KEY $SILO_USER@$SILO_HOST "curl -s http://localhost:8787/api/v1/health"
+    echo ""
+else
+    echo -e "$RED x dp1-feed failed to start. Check logs:$NC"
+    echo -e "$YELLOW   ssh -i $SSH_KEY $SILO_USER@$SILO_HOST journalctl -u dp1-feed -n 30$NC"
+    exit 1
+end
+
+echo ""
+echo -e "$GREEN Done. dp1-feed deployed to $SILO_HOST:8787$NC"

--- a/feed/landing-page.html
+++ b/feed/landing-page.html
@@ -1,0 +1,438 @@
+<!--
+DP-1 Feed Landing Page for feed.aesthetic.computer
+Live channel/playlist explorer backed by SQLite
+Created: 2026.02.20
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>feed · Aesthetic Computer</title>
+  <meta name="description" content="DP-1 feed server for Aesthetic Computer — playlists, channels, and KidLisp pieces">
+  <link rel="icon" type="image/png"
+    href="https://pals-aesthetic-computer.sfo3.cdn.digitaloceanspaces.com/painting-2023.7.29.20.39.png">
+
+  <style>
+    * { box-sizing: border-box; }
+    ::-webkit-scrollbar { display: none; }
+
+    body {
+      margin: 0;
+      font-size: 14px;
+      font-family: monospace;
+      -webkit-text-size-adjust: none;
+      background: #f5f5f5;
+      color: #000;
+      line-height: 1.4;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body { background: #111; color: #ddd; }
+      .card { background: #1a1a1a; }
+      .item-row { background: #1a1a1a; }
+      .item-row:hover { background: rgba(205, 92, 155, 0.08); }
+      .endpoint { background: rgba(205, 92, 155, 0.08); }
+      footer { border-top-color: rgba(205, 92, 155, 0.2); }
+    }
+
+    .container {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 1em 0.5em;
+    }
+
+    header {
+      text-align: center;
+      padding: 1em 0;
+      border-bottom: 2px solid rgb(205, 92, 155);
+      margin-bottom: 1em;
+    }
+
+    h1 {
+      margin: 0 0 0.1em 0;
+      font-size: 1.5em;
+      font-weight: normal;
+    }
+
+    h1 b { color: rgb(205, 92, 155); }
+
+    .subtitle {
+      color: #888;
+      font-size: 0.85em;
+      margin: 0;
+    }
+
+    .stats {
+      display: flex;
+      justify-content: center;
+      gap: 0.5em;
+      margin-top: 0.8em;
+      flex-wrap: wrap;
+      font-size: 0.75em;
+    }
+
+    .stat {
+      padding: 0.3em 0.6em;
+      background: rgba(205, 92, 155, 0.1);
+      border-radius: 3px;
+    }
+
+    .stat strong { color: rgb(205, 92, 155); }
+
+    .section-title {
+      font-size: 1.1em;
+      font-weight: normal;
+      margin: 1.5em 0 0.5em 0;
+      padding-bottom: 0.3em;
+      border-bottom: 1px solid rgba(205, 92, 155, 0.3);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .section-count {
+      font-size: 0.7em;
+      color: rgb(205, 92, 155);
+      font-weight: bold;
+    }
+
+    .card {
+      background: white;
+      border-radius: 4px;
+      padding: 1em;
+      margin-bottom: 0.5em;
+    }
+
+    .card-title {
+      font-weight: bold;
+      color: rgb(205, 92, 155);
+      margin-bottom: 0.3em;
+    }
+
+    .card-meta {
+      color: #888;
+      font-size: 0.85em;
+    }
+
+    .playlist-list {
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+    }
+
+    .item-row {
+      background: white;
+      padding: 0.75em;
+      border-bottom: 1px solid rgba(205, 92, 155, 0.1);
+      text-decoration: none;
+      color: inherit;
+      transition: all 0.15s;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 0.5em;
+      cursor: pointer;
+    }
+
+    .item-row:first-child { border-radius: 4px 4px 0 0; }
+    .item-row:last-child { border-radius: 0 0 4px 4px; border-bottom: none; }
+    .item-row:hover { background: rgba(205, 92, 155, 0.05); padding-left: 1em; }
+
+    .item-left {
+      display: flex;
+      align-items: center;
+      gap: 0.75em;
+      flex: 1;
+      min-width: 0;
+    }
+
+    .item-rank {
+      color: #aaa;
+      font-size: 0.8em;
+      width: 2em;
+      text-align: right;
+      flex-shrink: 0;
+    }
+
+    .item-info { min-width: 0; }
+
+    .item-title {
+      font-weight: bold;
+      color: rgb(205, 92, 155);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .item-summary {
+      font-size: 0.8em;
+      color: #888;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 500px;
+    }
+
+    .item-right {
+      display: flex;
+      align-items: center;
+      gap: 0.8em;
+      flex-shrink: 0;
+      font-size: 0.8em;
+      color: #aaa;
+    }
+
+    .badge {
+      padding: 0.15em 0.4em;
+      border-radius: 3px;
+      font-size: 0.8em;
+    }
+
+    .badge-dynamic {
+      background: rgba(205, 92, 155, 0.15);
+      color: rgb(205, 92, 155);
+    }
+
+    .badge-static {
+      background: rgba(100, 100, 100, 0.1);
+      color: #888;
+    }
+
+    .endpoint {
+      font-size: 0.85em;
+      padding: 0.4em 0.6em;
+      background: rgba(0,0,0,0.03);
+      border-radius: 3px;
+      margin-bottom: 0.3em;
+      display: flex;
+      gap: 0.5em;
+    }
+
+    .endpoint .method {
+      color: rgb(205, 92, 155);
+      font-weight: bold;
+      flex-shrink: 0;
+    }
+
+    .endpoint .path {
+      color: #555;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .endpoint .path { color: #aaa; }
+    }
+
+    .expand-items {
+      margin-top: 0.5em;
+      padding: 0.5em;
+      background: rgba(205, 92, 155, 0.05);
+      border-radius: 4px;
+      max-height: 400px;
+      overflow-y: auto;
+      font-size: 0.85em;
+      display: none;
+    }
+
+    .expand-items.open { display: block; }
+
+    .piece-row {
+      padding: 0.3em 0.5em;
+      display: flex;
+      gap: 0.5em;
+      align-items: center;
+      border-bottom: 1px solid rgba(205, 92, 155, 0.05);
+    }
+
+    .piece-row:last-child { border-bottom: none; }
+
+    .piece-code {
+      color: rgb(205, 92, 155);
+      font-weight: bold;
+      text-decoration: none;
+    }
+
+    .piece-code:hover { text-decoration: underline; }
+
+    .piece-rank {
+      color: #aaa;
+      width: 2.5em;
+      text-align: right;
+      flex-shrink: 0;
+      font-size: 0.9em;
+    }
+
+    .piece-title {
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    footer {
+      margin-top: 2em;
+      padding-top: 1em;
+      border-top: 1px solid rgba(205, 92, 155, 0.2);
+      text-align: center;
+      font-size: 0.8em;
+      color: #888;
+    }
+
+    footer a {
+      color: rgb(205, 92, 155);
+      text-decoration: none;
+    }
+
+    footer a:hover { text-decoration: underline; }
+
+    .loading { color: #aaa; font-style: italic; }
+    .err { color: #c44; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1><b>feed</b> · aesthetic computer</h1>
+      <p class="subtitle">DP-1 feed server &mdash; SQLite-backed playlists and channels</p>
+      <div class="stats" id="stats">
+        <span class="loading">connecting...</span>
+      </div>
+    </header>
+
+    <div id="channels-section"></div>
+    <div id="playlists-section"></div>
+
+    <div class="section-title">API</div>
+    <div id="endpoints">
+      <div class="endpoint"><span class="method">GET</span><span class="path">/api/v1</span></div>
+      <div class="endpoint"><span class="method">GET</span><span class="path">/api/v1/health</span></div>
+      <div class="endpoint"><span class="method">GET</span><span class="path">/api/v1/channels</span></div>
+      <div class="endpoint"><span class="method">GET</span><span class="path">/api/v1/channels/:id</span></div>
+      <div class="endpoint"><span class="method">GET</span><span class="path">/api/v1/playlists</span></div>
+      <div class="endpoint"><span class="method">GET</span><span class="path">/api/v1/playlists/:id</span></div>
+      <div class="endpoint"><span class="method">GET</span><span class="path">/api/v1/playlist-items</span></div>
+      <div class="endpoint"><span class="method">GET</span><span class="path">/api/v1/playlist-items/:id</span></div>
+    </div>
+
+    <footer>
+      <a href="https://github.com/display-protocol/dp1-feed">DP-1 Feed Operator</a> &middot;
+      <a href="https://aesthetic.computer">Aesthetic Computer</a> &middot;
+      <a href="https://aesthetic.computer/kidlisp">KidLisp</a>
+    </footer>
+  </div>
+
+  <script>
+    const API = '/api/v1';
+    const esc = s => { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; };
+
+    async function load() {
+      // Health / stats
+      try {
+        const health = await fetch(`${API}/health`).then(r => r.json());
+        const info = await fetch(`${API}`).then(r => r.json());
+        const el = document.getElementById('stats');
+        const parts = [];
+        if (info.version) parts.push(`<span class="stat">version <strong>${esc(info.version)}</strong></span>`);
+        if (info.deployment) parts.push(`<span class="stat">deployment <strong>${esc(info.deployment)}</strong></span>`);
+        if (health.status === 'ok') parts.push(`<span class="stat">status <strong>ok</strong></span>`);
+        if (info.runtime) parts.push(`<span class="stat">runtime <strong>${esc(info.runtime)}</strong></span>`);
+        el.innerHTML = parts.join('') || '<span class="stat">online</span>';
+      } catch (e) {
+        document.getElementById('stats').innerHTML = '<span class="err">offline</span>';
+      }
+
+      // Channels
+      try {
+        const data = await fetch(`${API}/channels`).then(r => r.json());
+        const items = data.items || [];
+        const sec = document.getElementById('channels-section');
+        if (items.length === 0) { sec.innerHTML = ''; return; }
+
+        let html = `<div class="section-title">Channels <span class="section-count">${items.length}</span></div>`;
+        for (const ch of items) {
+          const plCount = ch.playlists?.length || 0;
+          html += `<div class="card">
+            <div class="card-title">${esc(ch.title)}</div>
+            <div class="card-meta">${esc(ch.summary || '')}</div>
+            <div class="card-meta" style="margin-top:0.3em">
+              curator: ${esc(ch.curator || '-')} &middot; ${plCount} playlists &middot; ${esc(ch.slug || '')}
+            </div>
+          </div>`;
+        }
+        sec.innerHTML = html;
+      } catch (e) {}
+
+      // Playlists
+      try {
+        const data = await fetch(`${API}/playlists?limit=100`).then(r => r.json());
+        const items = data.items || [];
+        const sec = document.getElementById('playlists-section');
+        if (items.length === 0) { sec.innerHTML = ''; return; }
+
+        // Sort: dynamic (recently created) first, then static
+        items.sort((a, b) => new Date(b.created) - new Date(a.created));
+
+        let totalItems = 0;
+        items.forEach(p => totalItems += (p.items?.length || 0));
+
+        let html = `<div class="section-title">Playlists <span class="section-count">${items.length} playlists &middot; ${totalItems} items</span></div>`;
+        html += '<div class="playlist-list">';
+
+        items.forEach((p, i) => {
+          const count = p.items?.length || 0;
+          const isDynamic = (p.title || '').match(/^Top /);
+          const badgeClass = isDynamic ? 'badge-dynamic' : 'badge-static';
+          const badgeLabel = isDynamic ? 'dynamic' : 'static';
+          const created = p.created ? new Date(p.created).toLocaleDateString() : '';
+
+          html += `<div class="item-row" onclick="toggleItems('pl-${i}')">
+            <div class="item-left">
+              <span class="item-rank">#${i + 1}</span>
+              <div class="item-info">
+                <div class="item-title">${esc(p.title || p.slug)}</div>
+                <div class="item-summary">${esc(p.summary || '')}</div>
+              </div>
+            </div>
+            <div class="item-right">
+              <span class="badge ${badgeClass}">${badgeLabel}</span>
+              <span>${count} items</span>
+              <span>${created}</span>
+            </div>
+          </div>`;
+
+          // Expandable items list
+          if (p.items && p.items.length > 0) {
+            html += `<div class="expand-items" id="pl-${i}">`;
+            p.items.forEach((item, j) => {
+              const code = item.title || item.id || '-';
+              const url = item.url || '#';
+              // Extract AC piece URL from item
+              let pieceUrl = '#';
+              if (item.url) {
+                // DP-1 item URLs point to the piece
+                pieceUrl = item.url;
+              }
+              html += `<div class="piece-row">
+                <span class="piece-rank">${j + 1}.</span>
+                <a class="piece-code" href="${esc(pieceUrl)}" target="_blank">${esc(code)}</a>
+              </div>`;
+            });
+            html += '</div>';
+          }
+        });
+
+        html += '</div>';
+        sec.innerHTML = html;
+      } catch (e) {}
+    }
+
+    function toggleItems(id) {
+      const el = document.getElementById(id);
+      if (el) el.classList.toggle('open');
+    }
+
+    load();
+  </script>
+</body>
+</html>

--- a/feed/silo-update-top100.mjs
+++ b/feed/silo-update-top100.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+/**
+ * Silo-side KidLisp playlist updater
+ * Runs on silo.aesthetic.computer via systemd timer
+ *
+ * Regenerates dynamic playlists daily:
+ *   - Top 100 (all authors)
+ *   - Top @jeffrey
+ *   - Top @fifi
+ *
+ * Static playlists (Colors, Chords) are left untouched.
+ */
+
+import { MongoClient } from 'mongodb';
+
+const FEED_URL = process.env.FEED_URL || 'https://feed.aesthetic.computer/api/v1';
+const API_SECRET = process.env.FEED_API_SECRET;
+const MONGO_URI = process.env.MONGODB_CONNECTION_STRING;
+const MONGO_DB = process.env.MONGODB_NAME || 'aesthetic';
+const CHANNEL_ID = process.env.KIDLISP_CHANNEL_ID || '156c4235-4b24-4001-bec9-61ce0ac7c25e';
+
+// Dynamic playlists that get regenerated (order matters — matches channel slot order)
+// Channel playlist order: [Top 100, Top @jeffrey, Top @fifi, Colors, Chords]
+const DYNAMIC_PLAYLISTS = [
+  { slug: 'top-100', title: (d) => `Top 100 as of ${d}`, summary: 'The 100 most popular KidLisp pieces by total hits', handle: null, limit: 100 },
+  { slug: 'top-jeffrey', title: (d) => `Top @jeffrey as of ${d}`, summary: 'The most popular KidLisp pieces by @jeffrey', handle: 'jeffrey', limit: 100 },
+  { slug: 'top-fifi', title: (d) => `Top @fifi as of ${d}`, summary: 'The most popular KidLisp pieces by @fifi', handle: 'fifi', limit: 100 },
+];
+
+if (!API_SECRET) { console.error('FEED_API_SECRET required'); process.exit(1); }
+if (!MONGO_URI) { console.error('MONGODB_CONNECTION_STRING required'); process.exit(1); }
+
+const log = (msg) => console.log(`${new Date().toISOString()} ${msg}`);
+
+let mongoClient;
+
+async function getDb() {
+  if (!mongoClient) {
+    mongoClient = new MongoClient(MONGO_URI);
+    await mongoClient.connect();
+  }
+  return mongoClient.db(MONGO_DB);
+}
+
+async function getTopPieces(handle, limit) {
+  const db = await getDb();
+
+  const pipeline = [];
+
+  if (handle) {
+    // Look up the user ID for this handle
+    const handleDoc = await db.collection('@handles').findOne({ handle });
+    if (!handleDoc) {
+      log(`  warning: handle @${handle} not found`);
+      return [];
+    }
+    pipeline.push({ $match: { user: handleDoc._id } });
+  }
+
+  pipeline.push(
+    { $lookup: { from: '@handles', localField: 'user', foreignField: '_id', as: 'handleInfo' } },
+    { $sort: { hits: -1 } },
+    { $limit: limit },
+    { $project: { _id: 0, code: 1, hits: 1, handle: { $cond: { if: { $gt: [{ $size: '$handleInfo' }, 0] }, then: { $arrayElemAt: ['$handleInfo.handle', 0] }, else: null } } } },
+  );
+
+  return db.collection('kidlisp').aggregate(pipeline).toArray();
+}
+
+function buildPlaylist(config, pieces) {
+  const date = new Date().toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' });
+  const duration = 24;
+
+  return {
+    dpVersion: '1.1.0',
+    title: config.title(date),
+    summary: config.summary,
+    items: pieces.map((p, i) => ({
+      title: `$${p.code}`,
+      source: `https://device.kidlisp.com/$${p.code}?playlist=true&duration=${duration}&index=${i}&total=${pieces.length}`,
+      duration,
+      license: 'open',
+      provenance: { type: 'offChainURI', uri: `https://kidlisp.com/$${p.code}` },
+    })),
+    defaults: { display: { scaling: 'fit', background: '#000000', margin: '0%' }, license: 'open', duration: 24 },
+  };
+}
+
+async function api(method, path, body) {
+  const opts = {
+    method,
+    headers: { 'Authorization': `Bearer ${API_SECRET}`, 'Content-Type': 'application/json' },
+  };
+  if (body) opts.body = JSON.stringify(body);
+  const res = await fetch(`${FEED_URL}${path}`, opts);
+  if (!res.ok && res.status !== 404) {
+    throw new Error(`${method} ${path}: ${res.status} ${await res.text()}`);
+  }
+  if (res.status === 204 || res.status === 404) return null;
+  return res.json();
+}
+
+async function main() {
+  log('updating kidlisp playlists...');
+
+  // Get current channel
+  const channel = await api('GET', `/channels/${CHANNEL_ID}`);
+  const currentPlaylists = channel.playlists || [];
+
+  // Static playlists are at the end (Colors, Chords) — everything after the dynamic slots
+  const dynamicCount = DYNAMIC_PLAYLISTS.length;
+  const oldDynamicUrls = currentPlaylists.slice(0, dynamicCount);
+  const staticUrls = currentPlaylists.slice(dynamicCount);
+
+  // Generate each dynamic playlist
+  const newDynamicUrls = [];
+  const oldIdsToDelete = [];
+
+  for (const config of DYNAMIC_PLAYLISTS) {
+    const pieces = await getTopPieces(config.handle, config.limit);
+    log(`  ${config.slug}: ${pieces.length} pieces`);
+
+    if (pieces.length === 0) {
+      log(`  skipping ${config.slug} (no pieces)`);
+      // Keep old URL if it exists
+      const idx = DYNAMIC_PLAYLISTS.indexOf(config);
+      if (oldDynamicUrls[idx]) newDynamicUrls.push(oldDynamicUrls[idx]);
+      continue;
+    }
+
+    const playlist = buildPlaylist(config, pieces);
+    const created = await api('POST', '/playlists', playlist);
+    newDynamicUrls.push(`${FEED_URL}/playlists/${created.id}`);
+    log(`  ${config.slug}: created ${created.id}`);
+
+    // Track old playlist for deletion
+    const idx = DYNAMIC_PLAYLISTS.indexOf(config);
+    if (oldDynamicUrls[idx]) {
+      const oldId = oldDynamicUrls[idx].split('/').pop();
+      if (oldId !== created.id) oldIdsToDelete.push(oldId);
+    }
+  }
+
+  // Update channel: [dynamic playlists..., static playlists...]
+  const allPlaylistUrls = [...newDynamicUrls, ...staticUrls];
+  await api('PUT', `/channels/${CHANNEL_ID}`, {
+    title: channel.title,
+    curator: channel.curator,
+    summary: channel.summary,
+    playlists: allPlaylistUrls,
+  });
+  log(`  channel updated (${allPlaylistUrls.length} playlists)`);
+
+  // Delete old dynamic playlists
+  for (const oldId of oldIdsToDelete) {
+    await api('DELETE', `/playlists/${oldId}`);
+    log(`  deleted old: ${oldId}`);
+  }
+
+  // Clean up orphaned channels
+  const allChannels = await api('GET', '/channels');
+  for (const ch of (allChannels.items || [])) {
+    if (ch.id !== CHANNEL_ID) {
+      await api('DELETE', `/channels/${ch.id}`);
+    }
+  }
+
+  if (mongoClient) await mongoClient.close();
+  log('done.');
+}
+
+main().catch(e => {
+  console.error('FAILED:', e.message);
+  if (mongoClient) mongoClient.close();
+  process.exit(1);
+});

--- a/feed/update-top100.fish
+++ b/feed/update-top100.fish
@@ -1,0 +1,130 @@
+#!/usr/bin/env fish
+
+# Update the Top 100 KidLisp playlist on feed.aesthetic.computer
+# DEPRECATED: Use silo-update-top100.mjs on silo instead — it handles
+# all 3 dynamic playlists (Top 100, Top @jeffrey, Top @fifi).
+# This script only replaces slot 0 (Top 100) and is kept as a fallback.
+#
+# Usage:
+#   fish update-top100.fish          # Run from codespace / dev machine
+#   fish update-top100.fish --local  # Run directly on silo (no SSH tunnel needed)
+
+set SCRIPT_DIR (dirname (status --current-filename))
+set VAULT_DIR "$SCRIPT_DIR/../aesthetic-computer-vault"
+set VAULT_ENV "$VAULT_DIR/feed/.env"
+
+set LOCAL false
+if contains -- --local $argv
+    set LOCAL true
+end
+
+# Load vault env
+if test $LOCAL = true
+    if not set -q FEED_API_SECRET
+        echo "error: FEED_API_SECRET not set"
+        exit 1
+    end
+    if not set -q MONGODB_CONNECTION_STRING
+        echo "error: MONGODB_CONNECTION_STRING not set"
+        exit 1
+    end
+else
+    if not test -f $VAULT_ENV
+        echo "error: vault env not found at $VAULT_ENV"
+        exit 1
+    end
+    for line in (cat $VAULT_ENV | grep -v '^#' | grep '=')
+        set -l parts (string split -m1 '=' $line)
+        set -l val (string trim -c '"' $parts[2])
+        set -gx $parts[1] $val
+    end
+end
+
+set FEED_URL "https://feed.aesthetic.computer/api/v1"
+set CHANNEL_ID "$KIDLISP_CHANNEL_ID"
+if test -z "$CHANNEL_ID"
+    set CHANNEL_ID "156c4235-4b24-4001-bec9-61ce0ac7c25e"
+end
+
+echo (date -u +"%Y-%m-%d %H:%M:%S UTC")" updating top 100..."
+
+# Step 1: Get current channel
+set channel_json (curl -s "$FEED_URL/channels/$CHANNEL_ID" -H "Authorization: Bearer $FEED_API_SECRET")
+
+# Step 2: Generate new Top 100 playlist
+cd $SCRIPT_DIR
+set output (node create-top-kidlisp-playlist.mjs 2>&1)
+set new_top100_id (echo $output | grep -oP 'ID: \K[a-f0-9-]+' | head -1)
+
+if test -z "$new_top100_id"
+    echo "error: failed to create Top 100 playlist"
+    echo $output
+    exit 1
+end
+
+echo "  new Top 100: $new_top100_id"
+
+# Step 3: Build updated channel via node (avoid Fish JSON quoting issues)
+set update_result (node -e "
+const channelJson = JSON.parse(process.argv[1]);
+const newTop100Id = process.argv[2];
+const feedUrl = process.argv[3];
+const apiSecret = process.argv[4];
+const channelId = process.argv[5];
+
+// Keep non-Top-100 playlists (Colors, Chords), replace Top 100
+const staticPlaylists = (channelJson.playlists || []).filter(url => {
+    // Top 100 playlist URLs contain the old top100 ID — skip them
+    // Static playlists (Colors, Chords) stay
+    return true; // we'll replace all and rebuild
+});
+
+// Find static playlist IDs (not the first one, which is Top 100)
+const playlistUrls = channelJson.playlists || [];
+const staticUrls = playlistUrls.slice(1); // skip old Top 100
+
+// New channel playlists: [new Top 100, ...static]
+const newPlaylists = [
+    feedUrl + '/playlists/' + newTop100Id,
+    ...staticUrls
+];
+
+const body = {
+    title: channelJson.title,
+    curator: channelJson.curator,
+    summary: channelJson.summary,
+    playlists: newPlaylists
+};
+
+// Print old Top 100 ID for cleanup
+const oldTop100Url = playlistUrls[0] || '';
+const oldTop100Id = oldTop100Url.split('/').pop();
+console.log(JSON.stringify({ body, oldTop100Id }));
+" "$channel_json" "$new_top100_id" "$FEED_URL" "$FEED_API_SECRET" "$CHANNEL_ID" 2>/dev/null)
+
+set update_body (echo $update_result | python3 -c "import sys,json; print(json.dumps(json.load(sys.stdin)['body']))")
+set old_top100_id (echo $update_result | python3 -c "import sys,json; print(json.load(sys.stdin)['oldTop100Id'])")
+
+# Step 4: Update channel
+curl -s -X PUT "$FEED_URL/channels/$CHANNEL_ID" -H "Content-Type: application/json" -H "Authorization: Bearer $FEED_API_SECRET" -d "$update_body" > /dev/null
+echo "  channel updated"
+
+# Step 5: Delete old Top 100 playlist
+if test -n "$old_top100_id"; and test "$old_top100_id" != "$new_top100_id"
+    curl -s -X DELETE "$FEED_URL/playlists/$old_top100_id" -H "Authorization: Bearer $FEED_API_SECRET" > /dev/null
+    echo "  deleted old: $old_top100_id"
+end
+
+# Step 6: Clean up orphaned channels from create-top-kidlisp-playlist.mjs
+set orphans (curl -s "$FEED_URL/channels" -H "Authorization: Bearer $FEED_API_SECRET" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for c in d.get('items', []):
+    if c['id'] != '$CHANNEL_ID':
+        print(c['id'])
+" 2>/dev/null)
+for cid in $orphans
+    curl -s -X DELETE "$FEED_URL/channels/$cid" -H "Authorization: Bearer $FEED_API_SECRET" > /dev/null
+end
+
+echo (date -u +"%Y-%m-%d %H:%M:%S UTC")" done."

--- a/scores/feed.md
+++ b/scores/feed.md
@@ -1,0 +1,74 @@
+# Feed Score
+
+This score defines automated tasks for the KidLisp feed system on
+`feed.aesthetic.computer` (SQLite on silo).
+
+## Philosophy
+
+The feed is a living thing. The Top 100 playlist reflects what people
+are actually watching and making — it should stay fresh. Colors and
+Chords are fixed palettes that don't change. The channel is the
+container that holds everything together.
+
+Signal: a playlist that accurately reflects current activity.
+Noise: updating when nothing has changed.
+
+## Architecture
+
+```
+feed.aesthetic.computer (Caddy HTTPS)
+  -> localhost:8787 (dp1-feed, SQLite)
+     -> /api/v1/channels/156c4235-...  (KidLisp channel)
+        -> Top 100 playlist      (dynamic, daily)
+        -> Top @jeffrey playlist (dynamic, daily)
+        -> Top @fifi playlist    (dynamic, daily)
+        -> Colors playlist       (static)
+        -> Chords playlist       (static)
+```
+
+Backend: silo.aesthetic.computer, systemd service `dp1-feed`
+Storage: `/opt/dp1-feed/data/dp1-feed.db` (SQLite, WAL mode)
+Build script: `fish feed/build-feed.fish`
+Update script: `feed/silo-update-top100.mjs` (runs on silo)
+
+## Current Tasks
+
+### Daily (automated via systemd timer)
+
+- **Refresh dynamic playlists**: Query MongoDB for the most-hit KidLisp
+  pieces (overall and per-author), regenerate Top 100, Top @jeffrey,
+  and Top @fifi playlists, update the channel.
+  Colors and Chords are static and left untouched.
+  Script: `/opt/feed-updater/update-top100.mjs` on silo
+  Timer: `feed-update-top100.timer` on silo (runs daily at 06:00 UTC)
+
+### On Demand (run manually)
+
+- **Full rebuild**: Delete everything and regenerate all playlists
+  plus the channel from scratch.
+  Script: `fish feed/build-feed.fish`
+
+- **Add new playlist**: Create a new playlist generator script in
+  `feed/`, add it to `build-kidlisp-feed.mjs`, rebuild.
+
+### Future Ideas
+
+- Weekly "Rising" playlist: pieces gaining hits fastest this week
+- "New This Week" playlist: most recent KidLisp pieces
+- Seasonal rotation: swap out the channel's playlist order by season
+
+## Sacred Ground
+
+- Never delete the KidLisp channel without rebuilding it immediately
+- Never modify `dp1-feed/` submodule files from this score
+- The API secret lives in vault only — never hardcode it
+- Colors and Chords playlists are static — don't regenerate them
+  on the daily schedule (wastes IDs and breaks external references)
+
+## IDs
+
+```
+Channel:  156c4235-4b24-4001-bec9-61ce0ac7c25e
+Feed URL: https://feed.aesthetic.computer/api/v1
+Silo IP:  64.23.151.169
+```

--- a/silo/dashboard.html
+++ b/silo/dashboard.html
@@ -281,6 +281,7 @@ a:hover { text-decoration: underline; }
     <button class="tab-btn" data-tab="3">storage</button>
     <button class="tab-btn" data-tab="4">log</button>
     <button class="tab-btn" data-tab="5">firehose</button>
+    <button class="tab-btn" data-tab="6">feed</button>
   </div>
 
   <div class="panels">
@@ -304,6 +305,7 @@ a:hover { text-decoration: underline; }
           <div class="card-hd">services</div>
           <div class="kv"><span class="k"><span class="dot" id="svc-oven-dot"></span> oven</span><span class="v" id="svc-oven-meta">...</span></div>
           <div class="kv"><span class="k"><span class="dot" id="svc-session-dot"></span> session</span><span class="v" id="svc-session-meta">...</span></div>
+          <div class="kv"><span class="k"><span class="dot" id="svc-feed-dot"></span> feed</span><span class="v" id="svc-feed-meta">...</span></div>
           <div class="kv"><span class="k"><span class="dot" id="svc-insta-dot"></span> instagram</span><span class="v" id="svc-insta-meta">...</span></div>
           <div style="margin-top:8px">
             <div class="card-hd">redis</div>
@@ -361,6 +363,7 @@ a:hover { text-decoration: underline; }
         <div class="card-hd">services</div>
         <div class="kv"><span class="k"><span class="dot" id="svc-oven-dot2"></span> oven</span><span class="v" id="svc-oven-meta2">...</span></div>
         <div class="kv"><span class="k"><span class="dot" id="svc-session-dot2"></span> session</span><span class="v" id="svc-session-meta2">...</span></div>
+        <div class="kv"><span class="k"><span class="dot" id="svc-feed-dot2"></span> feed</span><span class="v" id="svc-feed-meta2">...</span></div>
       </div>
       <div class="card" style="margin-top:6px">
         <div class="card-hd">redis</div>
@@ -409,6 +412,32 @@ a:hover { text-decoration: underline; }
       </div>
       <div class="firehose-sidebar" id="firehoseCounters"></div>
       <canvas id="firehoseCanvas"></canvas>
+    </div>
+
+    <!-- feed (dp1-feed) -->
+    <div class="panel" data-panel="6">
+      <div class="overview-grid">
+        <div class="card">
+          <div class="card-hd">dp1-feed <b id="feed-runtime"></b></div>
+          <div class="kv"><span class="k">status</span><span class="v" id="feed-status">...</span></div>
+          <div class="kv"><span class="k">version</span><span class="v" id="feed-version">-</span></div>
+          <div class="kv"><span class="k">deployment</span><span class="v" id="feed-deployment">-</span></div>
+          <div class="kv"><span class="k">runtime</span><span class="v" id="feed-runtime-val">-</span></div>
+          <div class="kv"><span class="k">response</span><span class="v" id="feed-response">-</span></div>
+        </div>
+        <div class="card">
+          <div class="card-hd">endpoints</div>
+          <div id="feed-endpoints" style="font-size:11px;color:var(--fg2)">loading...</div>
+        </div>
+      </div>
+      <div class="card" style="margin-top:6px">
+        <div class="card-hd">playlists <b id="feed-playlist-count"></b></div>
+        <div id="feed-playlists" class="loading">loading...</div>
+      </div>
+      <div class="card" style="margin-top:6px">
+        <div class="card-hd">channels <b id="feed-channel-count"></b></div>
+        <div id="feed-channels" class="loading">loading...</div>
+      </div>
     </div>
   </div>
 </div>
@@ -771,7 +800,7 @@ async function loadStorage() {
   }
 }
 
-async function loadServices() { checkSvc('oven'); checkSvc('session'); }
+async function loadServices() { checkSvc('oven'); checkSvc('session'); checkSvc('feed'); }
 async function checkSvc(name) {
   try {
     const d = await authFetch('/api/services/' + name).then(r => r.json());
@@ -1198,6 +1227,7 @@ function setTab(idx) {
     requestAnimationFrame(() => el.scrollTop = el.scrollHeight);
   }
   if (idx === 5) { fhStart(); } else { fhStop(); }
+  if (idx === 6 && !feedLoaded) { loadFeed(); }
 }
 tabBtns.forEach(b => b.addEventListener('click', () => setTab(parseInt(b.dataset.tab))));
 setTab(activeTab);
@@ -1239,6 +1269,72 @@ document.getElementById('syncBtn').onclick = async () => {
     btn.textContent = 'sync from atlas'; btn.disabled = false;
   }
 };
+
+// --- feed tab ---
+let feedLoaded = false;
+async function loadFeed() {
+  feedLoaded = true;
+  try {
+    const info = await authFetch('/api/services/feed/info').then(r => r.json());
+    if (info.status === 'ok') {
+      document.getElementById('feed-status').textContent = 'online';
+      document.getElementById('feed-status').className = 'v ok';
+      document.getElementById('feed-version').textContent = info.version || '-';
+      document.getElementById('feed-deployment').textContent = info.deployment || '-';
+      document.getElementById('feed-runtime-val').textContent = info.runtime || '-';
+      document.getElementById('feed-response').textContent = info.responseMs + 'ms';
+      document.getElementById('feed-response').className = 'v ok';
+      const eps = info.endpoints;
+      if (eps) {
+        document.getElementById('feed-endpoints').innerHTML = Object.entries(eps)
+          .map(([k, v]) => '<div class="kv"><span class="k">' + esc(k) + '</span><span class="v">' + esc(v) + '</span></div>')
+          .join('');
+      }
+    } else {
+      document.getElementById('feed-status').textContent = 'unreachable';
+      document.getElementById('feed-status').className = 'v err';
+    }
+  } catch (e) {
+    document.getElementById('feed-status').textContent = 'error';
+    document.getElementById('feed-status').className = 'v err';
+  }
+
+  // Load playlists
+  try {
+    const data = await authFetch('/api/services/feed/playlists').then(r => r.json());
+    const el = document.getElementById('feed-playlists');
+    if (data.items && data.items.length > 0) {
+      document.getElementById('feed-playlist-count').textContent = data.items.length;
+      el.innerHTML = '<table class="tbl"><thead><tr><th>title</th><th>slug</th><th>items</th><th>created</th></tr></thead><tbody>' +
+        data.items.map(p => '<tr><td>' + esc(p.title || '-') + '</td><td>' + esc(p.slug || '-') + '</td><td class="r">' + (p.items?.length || 0) + '</td><td>' + (p.created ? new Date(p.created).toLocaleDateString() : '-') + '</td></tr>').join('') +
+        '</tbody></table>';
+    } else {
+      document.getElementById('feed-playlist-count').textContent = '0';
+      el.innerHTML = '<span style="color:var(--fg2)">no playlists</span>';
+    }
+    el.classList.remove('loading');
+  } catch (e) {
+    document.getElementById('feed-playlists').innerHTML = '<span class="loading">error</span>';
+  }
+
+  // Load channels
+  try {
+    const data = await authFetch('/api/services/feed/channels').then(r => r.json());
+    const el = document.getElementById('feed-channels');
+    if (data.items && data.items.length > 0) {
+      document.getElementById('feed-channel-count').textContent = data.items.length;
+      el.innerHTML = '<table class="tbl"><thead><tr><th>title</th><th>slug</th><th>playlists</th><th>created</th></tr></thead><tbody>' +
+        data.items.map(c => '<tr><td>' + esc(c.title || '-') + '</td><td>' + esc(c.slug || '-') + '</td><td class="r">' + (c.playlists?.length || 0) + '</td><td>' + (c.created ? new Date(c.created).toLocaleDateString() : '-') + '</td></tr>').join('') +
+        '</tbody></table>';
+    } else {
+      document.getElementById('feed-channel-count').textContent = '0';
+      el.innerHTML = '<span style="color:var(--fg2)">no channels</span>';
+    }
+    el.classList.remove('loading');
+  } catch (e) {
+    document.getElementById('feed-channels').innerHTML = '<span class="loading">error</span>';
+  }
+}
 
 function loadAll() {
   loadOverview(); loadCollections(); loadStorage(); loadServices(); loadBilling(); loadInstaStatus();

--- a/silo/server.mjs
+++ b/silo/server.mjs
@@ -875,6 +875,56 @@ app.get("/api/services/session", async (req, res) => {
   } catch (err) { res.json({ status: "unreachable", error: err.message }); }
 });
 
+app.get("/api/services/feed", async (req, res) => {
+  const url = process.env.FEED_URL || "http://localhost:8787";
+  try {
+    const start = Date.now();
+    const resp = await fetch(`${url}/api/v1/health`, { signal: AbortSignal.timeout(5000) });
+    const data = await resp.json();
+    res.json({ status: "ok", responseMs: Date.now() - start, ...data });
+  } catch (err) { res.json({ status: "unreachable", error: err.message }); }
+});
+
+app.get("/api/services/feed/info", async (req, res) => {
+  const url = process.env.FEED_URL || "http://localhost:8787";
+  try {
+    const start = Date.now();
+    const resp = await fetch(`${url}/api/v1`, { signal: AbortSignal.timeout(5000) });
+    const data = await resp.json();
+    res.json({ status: "ok", responseMs: Date.now() - start, ...data });
+  } catch (err) { res.json({ status: "unreachable", error: err.message }); }
+});
+
+app.get("/api/services/feed/playlists", async (req, res) => {
+  const url = process.env.FEED_URL || "http://localhost:8787";
+  const apiSecret = process.env.FEED_API_SECRET || "";
+  try {
+    const start = Date.now();
+    const headers = apiSecret ? { Authorization: `Bearer ${apiSecret}` } : {};
+    const resp = await fetch(`${url}/api/v1/playlists?limit=100`, {
+      headers,
+      signal: AbortSignal.timeout(10000),
+    });
+    const data = await resp.json();
+    res.json({ status: "ok", responseMs: Date.now() - start, ...data });
+  } catch (err) { res.json({ status: "unreachable", error: err.message }); }
+});
+
+app.get("/api/services/feed/channels", async (req, res) => {
+  const url = process.env.FEED_URL || "http://localhost:8787";
+  const apiSecret = process.env.FEED_API_SECRET || "";
+  try {
+    const start = Date.now();
+    const headers = apiSecret ? { Authorization: `Bearer ${apiSecret}` } : {};
+    const resp = await fetch(`${url}/api/v1/channels?limit=100`, {
+      headers,
+      signal: AbortSignal.timeout(10000),
+    });
+    const data = await resp.json();
+    res.json({ status: "ok", responseMs: Date.now() - start, ...data });
+  } catch (err) { res.json({ status: "unreachable", error: err.message }); }
+});
+
 app.get("/api/services/billing", async (req, res) => {
   const billingUrl = process.env.BILLING_URL || "https://aesthetic.computer/api/billing";
   try {


### PR DESCRIPTION
## Summary
- Migrated dp1-feed from Cloudflare Worker (KV storage) to self-hosted SQLite on silo.aesthetic.computer with Caddy TLS
- Added daily auto-updating playlists: Top 100, Top @jeffrey, Top @fifi (systemd timer at 06:00 UTC)
- Added feed tab to silo dashboard and feed service proxy endpoints
- Created `scores/feed.md` documenting feed architecture and automation

## Test plan
- [x] Verified `https://feed.aesthetic.computer/api/v1` responds with valid TLS
- [x] Verified channel has 5 playlists (Top 100, Top @jeffrey, Top @fifi, Colors, Chords)
- [x] Ran silo-update-top100.mjs — dynamic playlists regenerate, static ones preserved
- [x] Confirmed systemd timer active on silo (`feed-update-top100.timer`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)