### PR TITLE
notepat-remote: M4L relay device (ac-native → session-server → Ableton)

### DIFF
--- a/ac-m4l/AC-NotepatRemote.amxd.json
+++ b/ac-m4l/AC-NotepatRemote.amxd.json
@@ -1,0 +1,118 @@
+{
+  "patcher": {
+    "fileversion": 1,
+    "appversion": { "major": 9, "minor": 0, "revision": 7, "architecture": "x64", "modernui": 1 },
+    "classnamespace": "box",
+    "rect": [100, 100, 700, 500],
+    "openrect": [0, 0, 360, 220],
+    "openinpresentation": 1,
+    "gridsize": [15, 15],
+    "enablehscroll": 0,
+    "enablevscroll": 0,
+    "devicewidth": 360,
+    "description": "Receive ac-native notepat MIDI via session-server relay and emit to this track",
+    "boxes": [
+      {
+        "box": {
+          "disablefind": 0,
+          "id": "obj-jweb",
+          "latency": 0,
+          "maxclass": "jweb~",
+          "numinlets": 1,
+          "numoutlets": 3,
+          "outlettype": ["signal", "signal", ""],
+          "patching_rect": [10, 10, 360, 220],
+          "presentation": 1,
+          "presentation_rect": [0, 0, 360, 220],
+          "rendermode": 1,
+          "url": "https://aesthetic.computer/notepat-remote?daw=1&nogap"
+        }
+      },
+      {
+        "box": {
+          "comment": "Strip 'note' and 'channel' keywords from jweb messages",
+          "id": "obj-route",
+          "maxclass": "newobj",
+          "numinlets": 1,
+          "numoutlets": 3,
+          "outlettype": ["", "", ""],
+          "patching_rect": [10, 250, 180, 22],
+          "text": "route note channel"
+        }
+      },
+      {
+        "box": {
+          "comment": "Emit MIDI into the track's next device",
+          "id": "obj-noteout",
+          "maxclass": "newobj",
+          "numinlets": 2,
+          "numoutlets": 0,
+          "patching_rect": [10, 300, 60, 22],
+          "text": "noteout"
+        }
+      },
+      {
+        "box": {
+          "comment": "Debug: unmatched messages land here",
+          "id": "obj-print",
+          "maxclass": "newobj",
+          "numinlets": 1,
+          "numoutlets": 0,
+          "patching_rect": [200, 300, 200, 22],
+          "text": "print NOTEPAT-REMOTE"
+        }
+      },
+      {
+        "box": {
+          "id": "obj-thisdevice",
+          "maxclass": "newobj",
+          "numinlets": 1,
+          "numoutlets": 3,
+          "outlettype": ["bang", "int", "int"],
+          "patching_rect": [420, 250, 90, 22],
+          "text": "live.thisdevice"
+        }
+      },
+      {
+        "box": {
+          "id": "obj-routeready",
+          "maxclass": "newobj",
+          "numinlets": 1,
+          "numoutlets": 2,
+          "outlettype": ["", ""],
+          "patching_rect": [420, 280, 60, 22],
+          "text": "route ready"
+        }
+      },
+      {
+        "box": {
+          "comment": "Tell jweb~ page we are live (page can use this to trigger subscribe)",
+          "id": "obj-activate",
+          "maxclass": "message",
+          "numinlets": 2,
+          "numoutlets": 1,
+          "outlettype": [""],
+          "patching_rect": [420, 310, 90, 22],
+          "text": "script daw-activate"
+        }
+      }
+    ],
+    "lines": [
+      { "patchline": { "source": ["obj-jweb", 2], "destination": ["obj-route", 0] } },
+      { "patchline": { "source": ["obj-route", 0], "destination": ["obj-noteout", 0] } },
+      { "patchline": { "source": ["obj-route", 1], "destination": ["obj-noteout", 1] } },
+      { "patchline": { "source": ["obj-route", 2], "destination": ["obj-print", 0] } },
+      { "patchline": { "source": ["obj-thisdevice", 0], "destination": ["obj-routeready", 0] } },
+      { "patchline": { "source": ["obj-routeready", 0], "destination": ["obj-activate", 0] } },
+      { "patchline": { "source": ["obj-activate", 0], "destination": ["obj-jweb", 0] } }
+    ],
+    "dependency_cache": [],
+    "latency": 0,
+    "is_mpe": 0,
+    "external_mpe_tuning_enabled": 0,
+    "minimum_live_version": "",
+    "minimum_max_version": "",
+    "platform_compatibility": 0,
+    "autosave": 0
+  }
+}

--- a/ac-m4l/devices.json
+++ b/ac-m4l/devices.json
@@ -57,6 +57,16 @@
       "type": "midi",
       "source": "AC-KnobMap.amxd.json",
       "version": "1.0.5"
+    },
+    {
+      "name": "AC 🎹 notepat-remote (aesthetic.computer)",
+      "piece": "notepat-remote",
+      "description": "Relay MIDI from ac-native notepat (ThinkPad) to this track via session-server",
+      "width": 360,
+      "height": 220,
+      "type": "midi",
+      "source": "AC-NotepatRemote.amxd.json",
+      "version": "0.1.0"
     }
   ],
   "defaults": {

--- a/fedac/native/pieces/notepat.mjs
+++ b/fedac/native/pieces/notepat.mjs
@@ -325,6 +325,13 @@ let usbMidiNextRefreshFrame = 0;
 let usbMidiTypecSignature = "";
 let udpMidiBroadcast = false;
 let udpMidiNextHeartbeatFrame = 0;
+// Connectivity telemetry for the UDP midi relay overlay
+let udpMidiSentCount = 0;
+let udpMidiOnCount = 0;
+let udpMidiOffCount = 0;
+let udpMidiLastPitch = -1;
+let udpMidiLastVelocity = 0;
+let udpMidiLastSentFrame = -9999;
 
 
 // OS update panel state machine
@@ -1830,6 +1837,15 @@ function loadUdpMidiConfig(system) {
 function sendUdpMidiEvent(system, event, midiNote, velocity, channel = 0) {
   if (!udpMidiBroadcast || !system?.udp?.connected) return;
   system?.udp?.sendMidi?.(event, midiNote, velocity, channel, "notepat");
+  udpMidiSentCount += 1;
+  if (event === "note_off" || (event === "note_on" && velocity === 0)) {
+    udpMidiOffCount += 1;
+  } else {
+    udpMidiOnCount += 1;
+  }
+  udpMidiLastPitch = midiNote;
+  udpMidiLastVelocity = velocity;
+  udpMidiLastSentFrame = frame;
 }
 
 function maybeSendUdpMidiHeartbeat(system) {
@@ -1842,8 +1858,19 @@ function maybeSendUdpMidiHeartbeat(system) {
 function udpMidiRelayStatusText(system) {
   if (!udpMidiBroadcast) return "";
   const handle = system?.udp?.handle || system?.config?.handle || "";
-  if (system?.udp?.connected) return handle ? "relay @" + handle : "relay on";
-  return handle ? "relay ...@" + handle : "relay ...";
+  const connected = !!system?.udp?.connected;
+  const prefix = connected
+    ? (handle ? "relay @" + handle : "relay on")
+    : (handle ? "relay ...@" + handle : "relay ...");
+  // Append counters + last note when actively sending so the overlay shows
+  // the ThinkPad actually broadcasts notes (and not just that the socket is up).
+  if (!connected) return prefix;
+  if (udpMidiSentCount === 0) return prefix + " 0";
+  const recent = frame - udpMidiLastSentFrame < 90; // ~1.5s fresh window
+  const tail = recent && udpMidiLastPitch >= 0
+    ? ` ${udpMidiSentCount} ${udpMidiLastPitch}v${udpMidiLastVelocity}`
+    : ` ${udpMidiSentCount}`;
+  return prefix + tail;
 }
 
 function rememberSound(key, entry, system, velocity = 1) {

--- a/system/public/aesthetic.computer/disks/notepat-remote.mjs
+++ b/system/public/aesthetic.computer/disks/notepat-remote.mjs
@@ -1,0 +1,248 @@
+// notepat-remote, 26.4.20
+// AC 🎹 Notepat Remote — receives notepat:midi events from session-server
+// and bridges them to Max for Live via window.max.outlet.
+//
+// Meant to load inside jweb~ in AC-NotepatRemote.amxd. When opened standalone
+// in a browser it still renders the connection status UI (MIDI out is a no-op).
+//
+// Wire path:
+//   ThinkPad ac-native notepat.mjs
+//     → UDP :10010 → session-server.aesthetic.computer
+//     → WS fanout → this piece
+//     → window.max.outlet(["note", pitch, vel]) → Max [route note] → [noteout]
+
+const { floor, min, max } = Math;
+
+const WS_URL = "wss://session-server.aesthetic.computer/";
+const RECONNECT_FRAMES = 120; // ~2s @ 60fps
+
+let ws = null;
+let wsState = "idle"; // idle | connecting | open | closed | error
+let wsError = "";
+let reconnectAt = 0;
+
+let sources = []; // [{ handle, machineId, piece, lastSeen }]
+let pktCount = 0;
+let noteOnCount = 0;
+let noteOffCount = 0;
+let lastNote = null; // { pitch, vel, chan, event, handle, ts, latencyMs }
+let lastNoteFrame = -9999;
+
+let frame = 0;
+let lastSubscribedCh = -1;
+
+// Max for Live jweb~ bridge (exposes window.max.outlet)
+const maxBridge =
+  typeof window !== "undefined" &&
+  window.max &&
+  typeof window.max.outlet === "function"
+    ? window.max
+    : null;
+
+function emitMaxNote(pitch, velocity, channel) {
+  if (!maxBridge) return;
+  try {
+    if (channel !== lastSubscribedCh) {
+      maxBridge.outlet(["channel", channel]);
+      lastSubscribedCh = channel;
+    }
+    maxBridge.outlet(["note", pitch, velocity]);
+  } catch (_err) {}
+}
+
+function connectWs() {
+  if (typeof WebSocket === "undefined") return;
+  if (ws && (ws.readyState === 0 || ws.readyState === 1)) return;
+  try {
+    wsState = "connecting";
+    wsError = "";
+    ws = new WebSocket(WS_URL);
+    ws.onopen = () => {
+      wsState = "open";
+      try {
+        ws.send(
+          JSON.stringify({
+            type: "notepat:midi:subscribe",
+            content: { all: true },
+          }),
+        );
+      } catch (_e) {}
+    };
+    ws.onmessage = (ev) => {
+      let msg;
+      try {
+        msg = JSON.parse(ev.data);
+      } catch {
+        return;
+      }
+      if (!msg || !msg.type) return;
+      if (msg.type === "notepat:midi") {
+        handleMidiEvent(msg.content || {});
+      } else if (msg.type === "notepat:midi:sources") {
+        const list = (msg.content && msg.content.sources) || [];
+        sources = list.map((s) => ({
+          handle: s.handle || "",
+          machineId: s.machineId || "",
+          piece: s.piece || "notepat",
+          lastSeen: s.lastSeen || 0,
+        }));
+      }
+    };
+    ws.onerror = () => {
+      wsState = "error";
+      wsError = "ws error";
+    };
+    ws.onclose = () => {
+      wsState = "closed";
+      reconnectAt = frame + RECONNECT_FRAMES;
+    };
+  } catch (err) {
+    wsState = "error";
+    wsError = err?.message || "connect failed";
+    reconnectAt = frame + RECONNECT_FRAMES;
+  }
+}
+
+function handleMidiEvent(ev) {
+  const pitch = Number(ev.note);
+  const vel = Number(ev.velocity);
+  const chan = Number(ev.channel) || 0;
+  if (!Number.isFinite(pitch) || !Number.isFinite(vel)) return;
+  pktCount += 1;
+  const now = Date.now();
+  const tsNum = Number(ev.ts);
+  const latency = Number.isFinite(tsNum) ? max(0, now - tsNum) : 0;
+  const isOff = ev.event === "note_off" || (ev.event === "note_on" && vel === 0);
+  if (isOff) {
+    noteOffCount += 1;
+    emitMaxNote(pitch, 0, chan);
+  } else {
+    noteOnCount += 1;
+    emitMaxNote(pitch, max(1, min(127, vel)), chan);
+  }
+  lastNote = {
+    pitch,
+    vel,
+    chan,
+    event: ev.event || (isOff ? "note_off" : "note_on"),
+    handle: ev.handle || "",
+    ts: now,
+    latencyMs: latency,
+  };
+  lastNoteFrame = frame;
+}
+
+const PITCH_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+function pitchName(p) {
+  const n = PITCH_NAMES[((p % 12) + 12) % 12];
+  const o = floor(p / 12) - 1;
+  return n + o;
+}
+
+function boot({ wipe, cursor }) {
+  wipe(8, 10, 18);
+  cursor?.("native");
+  connectWs();
+}
+
+function sim() {
+  frame += 1;
+  if (wsState === "closed" && frame >= reconnectAt) connectWs();
+}
+
+function paint({ wipe, ink, box, line, screen }) {
+  const bg = [8, 10, 18];
+  const fg = [220, 225, 255];
+  const fgDim = [130, 140, 170];
+  const accent = [255, 170, 80];
+  const good = [140, 255, 180];
+  const bad = [255, 120, 120];
+  const warn = [255, 220, 100];
+  wipe(...bg);
+
+  const W = screen.width;
+  const H = screen.height;
+  let y = 4;
+
+  // Header + bridge badge
+  ink(...accent).write("NOTEPAT-REMOTE", { x: 4, y, size: 1 });
+  ink(...(maxBridge ? good : warn)).write(
+    maxBridge ? "[M4L]" : "[solo]",
+    { x: 112, y },
+  );
+  y += 10;
+
+  // WS status line
+  const stateColor =
+    wsState === "open"
+      ? good
+      : wsState === "connecting"
+        ? warn
+        : wsState === "error" || wsState === "closed"
+          ? bad
+          : fgDim;
+  ink(...fgDim).write("ws", { x: 4, y });
+  ink(...stateColor).write(wsState.toUpperCase(), { x: 18, y });
+  if (wsError) ink(...bad).write(wsError.slice(0, 24), { x: 60, y });
+  y += 8;
+
+  // Sources
+  ink(...fgDim).write("src", { x: 4, y });
+  if (sources.length === 0) {
+    ink(...fgDim).write("(none — start relay on)", { x: 18, y });
+  } else {
+    const label = sources
+      .slice(0, 4)
+      .map((s) => (s.handle ? "@" + s.handle : s.machineId.slice(0, 6)))
+      .join(" ");
+    ink(...fg).write(label.slice(0, 36), { x: 18, y });
+  }
+  y += 8;
+
+  // Counters
+  ink(...fgDim).write(
+    `pkt ${pktCount}  on ${noteOnCount}  off ${noteOffCount}`,
+    { x: 4, y },
+  );
+  y += 10;
+
+  // Last note — flashes accent, fades to fg over ~30 frames
+  if (lastNote) {
+    const age = frame - lastNoteFrame;
+    const flashing = age < 30;
+    const color = flashing ? accent : fg;
+    const arrow = lastNote.vel === 0 || lastNote.event === "note_off" ? "v" : "^";
+    const label = `${arrow} ${pitchName(lastNote.pitch)} (${lastNote.pitch}) vel ${lastNote.vel} ch ${lastNote.chan}`;
+    ink(...color).write(label, { x: 4, y });
+    y += 8;
+    const who = lastNote.handle ? "@" + lastNote.handle : "?";
+    ink(...fgDim).write(`${who}  ${lastNote.latencyMs}ms`, { x: 4, y });
+    y += 10;
+  } else {
+    ink(...fgDim).write("(waiting for notes…)", { x: 4, y });
+    y += 10;
+  }
+
+  // Indicator strip at bottom — one bar per source, bars flash on note
+  if (H - y > 14) {
+    const barY = H - 10;
+    ink(...fgDim).line(2, barY - 1, W - 2, barY - 1);
+    ink(...fg).write("hint: enable on ThinkPad: 'midi relay on'", { x: 4, y: H - 8 });
+  }
+}
+
+function leave() {
+  try {
+    ws?.close();
+  } catch {}
+  ws = null;
+}
+
+function meta() {
+  return {
+    title: "Notepat Remote",
+    desc: "Max for Live bridge: session-server notepat:midi → MIDI track",
+  };
+}
+
+export { boot, sim, paint, leave, meta };


### PR DESCRIPTION
## Summary
- Adds **AC 🎹 notepat-remote** Max for Live MIDI Effect device that subscribes to session-server's existing `notepat:midi` WS fanout and emits MIDI into whatever track it's on.
- Pairs with the **already-wired UDP broadcast** from `fedac/native/pieces/notepat.mjs` (UDP to `session-server.aesthetic.computer:10010`). ThinkPad keys → prod session-server → this M4L device on Mac → track instrument.
- Zero session-server changes needed — all relay handlers (`notepat:midi:subscribe`, `broadcastNotepatMidiEvent`, UDP ingest at port 10010) are live in prod (verified via WS probe during dev).

## What's deployed on prod via this PR
- New piece served at `https://aesthetic.computer/notepat-remote` — the page that loads inside the device's `jweb~` and talks to `wss://session-server.aesthetic.computer/`.

## Artifacts this commit also touches (no prod runtime impact)
- `ac-m4l/AC-NotepatRemote.amxd.json` — Max patcher source (for `python3 ac-m4l/build.py notepat-remote --production`).
- `ac-m4l/devices.json` — registers the device for `build.py`.
- `fedac/native/pieces/notepat.mjs` — pkt/note counters feed the existing `udpMidiRelayStatusText` so the ThinkPad status bar shows `relay @handle 42 60v100` when broadcasting. Only affects ac-native OS builds.

## Test plan
- [ ] `python3 ac-m4l/build.py notepat-remote --production` produces `AC 🎹 notepat-remote (aesthetic.computer).amxd`
- [ ] After merge: `curl -I https://aesthetic.computer/notepat-remote` returns 200 (currently 404)
- [ ] Drop .amxd onto an Ableton MIDI track (before an instrument)
- [ ] On ThinkPad: `midi relay on` in prompt, open notepat, strike keys
- [ ] Device UI shows `ws OPEN`, `[M4L]`, source `@yourhandle`, pkt count increments, last note flashes
- [ ] Track instrument actually plays the notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)