### PR TITLE
GRAPHICS.md — inline-graphics guide (companion to HAND + VOICE)

### DIFF
--- a/GRAPHICS.md
+++ b/GRAPHICS.md
@@ -1,0 +1,84 @@
+# Graphics — an inline-rendering guide for GitHub
+
+companion to `HAND.md` and `papers/VOICE.md`. HAND governs how the code reads, VOICE how the papers sound; this governs how a **PR, issue, or repo `.md` draws** — pictures that render on github.com from text alone.
+
+it exists because the reflex is to drag in a screenshot. a screenshot drifts the moment the code moves and can't be reviewed as a diff. a diagram written *in text*, beside the change, can't drift — it versions with the thing it explains. so: prefer the mark you can type.
+
+## the one rule
+
+**if it isn't a fence or `$math$`, it doesn't render.** github runs every markdown surface through a sanitizer. know the line and you stop guessing.
+
+## what renders inline — verified on github.com
+
+- **`​```mermaid`** — diagrams *and* charts. flow, sequence, state, er, class — and `pie`, `xychart-beta`, `sankey-beta`, `quadrantChart` for data. `classDef` colors nodes (the ac chartreuse-on-black look stays in text).
+- **`$…$` / `​```math`** — equations. `\color{…}{…}` and `\bbox[bg]{…}` tint *real content*. that's the whole of what math draws — see the dead end below.
+- **`​```geojson` / `​```topojson`** — an interactive leaflet map.
+- **braille / block art in a plain `​```` ` fence** — the only way to draw *arbitrary* art inline. low-res, but anything.
+- **prose primitives** — tables, task lists, `<details>`, `> [!NOTE]` alerts, footnotes.
+
+## what does not render — and why
+
+| you reach for | what happens | because |
+|---|---|---|
+| inline `<svg>…</svg>` | stripped | sanitizer |
+| `data:` uri in `<img>` | stripped | sanitizer |
+| `<script>` / `<style>` / iframe / raw css | stripped | sanitizer |
+| math `\rule{w}{h}` pixel art | **"unable to render"** | `\rule` is a *text-mode* tex command; mathjax implements only math-mode macros |
+| math `\colorbox{…}{…}` grid | broken | broken on github since may 2023, not restored |
+| `\begin{array}{@{}c@{}…}` + `\\[-Npt]` | **"unable to render"** | the `@{}` column spec and negative row gaps aren't supported |
+
+**the trap:** every `\textcolor{red}{\rule{…}}` "colored square" example on the web is a *native-latex → png* tool (readme2tex and kin). those commit an image. they do not work in github's mathjax. don't chase them — i did, it's a dead end.
+
+## draw anything inline: braille
+
+`\rule` is gone, so arbitrary art comes down to **unicode braille** (U+2800–28FF). each glyph is a 2×4 dot grid, so a generated field of glyphs is a 1-bit raster that renders anywhere monospace. `toolchain/art-to-braille.mjs` does it from a shape or from any png:
+
+```
+node toolchain/art-to-braille.mjs smiley
+node toolchain/art-to-braille.mjs flower
+node toolchain/art-to-braille.mjs image pic.png 50 [--invert]
+```
+
+it shells out to `sips` to normalize/resize, decodes the png with node's built-in `zlib` (no image library), thresholds luminance, packs the dots. a smiley:
+
+```
+⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⣀⣀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⣤⣴⣶⣾⣿⣿⠿⠿⠿⠿⢿⣿⣿⣶⣶⣤⣄⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+⠀⠀⠀⠀⠀⠀⠀⢀⣠⣶⣿⡿⠟⠋⠉⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠉⠛⠿⣿⣷⣦⣀⠀⠀⠀⠀⠀⠀⠀
+⠀⠀⠀⠀⠀⢀⣴⣿⡿⠛⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠙⠻⣿⣷⣄⠀⠀⠀⠀⠀
+⠀⠀⠀⠀⣰⣿⡿⠋⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠻⣿⣷⡀⠀⠀⠀
+⠀⠀⠀⣼⣿⡟⠁⠀⠀⠀⠀⢰⣿⣿⣷⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢰⣿⣿⣷⠀⠀⠀⠀⠀⠙⣿⣿⡄⠀⠀
+⠀⠀⢰⣿⣿⠁⠀⠀⠀⠀⠀⠈⠛⠛⠋⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠛⠛⠋⠀⠀⠀⠀⠀⠀⢹⣿⣷⠀⠀
+⠀⠀⣿⣿⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⣿⡇⠀
+⠀⠀⣿⣿⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⣿⡇⠀
+⠀⠀⢹⣿⣷⠀⠀⠀⠀⠀⢿⣿⣇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣿⣿⠇⠀⠀⠀⠀⢰⣿⣿⠁⠀
+⠀⠀⠀⢿⣿⣇⠀⠀⠀⠀⠘⢿⣿⣆⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣾⣿⠟⠀⠀⠀⠀⢀⣿⣿⠇⠀⠀
+⠀⠀⠀⠈⢻⣿⣧⡀⠀⠀⠀⠈⠻⣿⣷⣦⣄⡀⠀⠀⠀⠀⠀⣀⣤⣶⣿⡿⠋⠀⠀⠀⠀⣠⣿⣿⠋⠀⠀⠀
+⠀⠀⠀⠀⠀⠙⢿⣿⣦⣀⠀⠀⠀⠀⠉⠛⠿⢿⣿⣿⣿⣿⣿⠿⠟⠋⠁⠀⠀⠀⢀⣠⣾⣿⠟⠁⠀⠀⠀⠀
+⠀⠀⠀⠀⠀⠀⠀⠙⠻⣿⣷⣦⣄⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⣤⣶⣿⡿⠛⠁⠀⠀⠀⠀⠀⠀
+⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠛⠿⢿⣿⣷⣶⣶⣤⣤⣤⣤⣴⣶⣶⣿⣿⠿⠟⠋⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀
+⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠉⠉⠙⠛⠛⠛⠉⠉⠉⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+```
+
+limits: low resolution, 1-bit (no grayscale or color), and it wants a monospace font with braille coverage. right for icons, logos, mascots, diagram-art — wrong for photos. for a photo, you've left inline-only: commit a code-generated svg/png and reference it by path.
+
+## picking a method
+
+```mermaid
+flowchart TD
+  q{show what?} --> d{flow / state?}
+  d -->|yes| mer[mermaid diagram]
+  d -->|no| c{quantities?}
+  c -->|yes| chart[mermaid chart]
+  c -->|no| f{formula?}
+  f -->|yes| math[math block]
+  f -->|no| g{geographic?}
+  g -->|yes| geo[geojson]
+  g -->|no| br[braille — shape or png]
+```
+
+label nodes with the real names — `disk.mjs`, `session-server`, not "service a". a diagram that names the code is navigable; boxes of abstractions are decoration. (same instinct as HAND: knowability first.)
+
+## the papers caveat
+
+none of this reaches the `papers/` xelatex pdfs — mermaid and mathjax are a github.com feature. in a paper the equivalents are native and better: tikz for diagrams, real latex math, `pgfplots` for charts, `\includegraphics` for raster. this guide is for the github surface — prs, rfcs, issues, readmes.

--- a/HAND.md
+++ b/HAND.md
@@ -1,6 +1,6 @@
 # The Hand — a code style guide for Aesthetic Computer
 
-companion to `papers/VOICE.md`. VOICE.md governs how papers *sound*; this governs how the code *reads*.
+companion to `papers/VOICE.md` and `GRAPHICS.md`. VOICE.md governs how papers *sound*, GRAPHICS.md how a PR or doc *draws*; this governs how the code *reads*.
 
 it exists because of what *The Hand and the Loop* (`papers/arxiv-hand-and-loop`) found: across three eras the codebase gained velocity and breadth and lost the instrument — the terse, single-mind discipline of the hand-written years. this guide is how the hand gets handed back to the loop. an agent that reads this should write code that knows it's part of an instrument, not just code that runs.
 

--- a/pop/RELEASES.md
+++ b/pop/RELEASES.md
@@ -19,6 +19,7 @@ All AC YouTube cuts are **1920×1080 landscape only** (vertical = Short, metadat
 | Helpabeach (v3) | [KVynj0RAwg8](https://youtu.be/KVynj0RAwg8) | `preview-score-helpabeach-yt.mjs` — multiply vignette half of `drawBacklight` dropped (warm sunset screen-glow kept); replaces v2 `WKdMYawwDPY` (deleted 2026-05-29 for the same side-darkening complaint) |
 | Amaythingra | [2FwOYCXS4UA](https://youtu.be/2FwOYCXS4UA) | `preview-score-yt.mjs` (big-pictures fork) — 32 cinematic beats, 3 render modes (photoreal office / glossy-grey metaverse / psychedelic AC-glitch degradation); chrome: per-slide tint, stained-glass colour-sep backlight, radial chromatic+blur edge-warp, glowy lanes, slide-blink bar, shimmer labels, kick beat-bump. Replaces `-at3b-chBbE`/`F-RhEL9OQ1g`/`KpK_MV8-178` (all deleted) |
 | Hellsine (v2) | [IjMGmPDvO4I](https://youtu.be/IjMGmPDvO4I) | `preview-score-hellsine-yt.mjs` — `drawVignette(c, v_i)` call removed from `paintSectionPanel` (function kept as dead code, mirrors marimbaba v3 / trancepenta-yt fix); replaces v1 `9KPUr6mA5e8` (deleted 2026-05-29, side-darkening crushed the felt-puppet panel edges); promoted to public 2026-05-29 |
+| Momabobasheep | [GCOhg5J-brw](https://youtu.be/GCOhg5J-brw) | **listener video** (not a preview-score cut) — 15 felt Seedance clips (`pop/momboba/video/board.json` + `build.mjs` driver, auditioned in ShotWizard) cycling so no clip repeats back-to-back, each under a fresh crop drift, smooth xfade dissolves between scenes, trimmed jumpy tails + slo-mo + stop-motion fps, gentle wavy displacement + film grain + unsharp, staggered pals badges (left low / right high, pals leading each rotated title column). `bin/assemble-listener.mjs` (cycling/crossfade plate) + `bin/chrome-listener.mjs`. Public 2026-06-17 |
 
 YouTube API quota: **6 video_insert / day / project** (`defaultVideoInsertPerDayPerProject`); deletes count toward the same window. On 2026-05-29 the de-vignette pass burned 5 of 6 (hellsine v1 upload at 02:04Z + delete hellsine v1 + delete helpabeach v2 + upload hellsine v2 + upload helpabeach v3) — next YT churn must wait for the 24h rolling window to clear.
 
@@ -714,6 +715,22 @@ DistroKid has a "request Spotify for Artists" shortcut for new artists.
   --reel split for the Reels UI). Canvas: `bin/build-canvas.mjs` —
   8 s silent ping-pong of the dream take. Audio bed = the track from
   5:20, swelling into THE DREAM's golden-section climax.
+- **YouTube (2026-06-17):** listener video PUBLIC →
+  <https://youtu.be/GCOhg5J-brw> (1920×1080, 10:00, ~1.07 GB). NOT a
+  preview-score cut — a new **listener** pipeline: 15 felt Seedance clips
+  (the 9 movement scenes + 6 added vignettes: boba-macro, sheep-sky,
+  pond-koi, color-field, night-moon, and a closing **sketchbook** shot that
+  feeds the day's prior stills forward as gpt-image-2 refs so the pages
+  relive the day) **cycled** so no clip repeats back-to-back, each under a
+  fresh crop drift, **xfade dissolves** between every scene, trimmed jumpy
+  tails + slo-mo + stop-motion fps, gentle wavy displacement + film grain +
+  unsharp, staggered pals side-badges (left low / right high, pals leading
+  each rotated title column). Storyboarded/auditioned in **ShotWizard**
+  (`pop/momboba/video/board.json` + `build.mjs` driver: `--shot <id>` gens
+  still+clip, `--assemble` cuts the full video). Built by
+  `bin/assemble-listener.mjs` (cycling/crossfade plate) →
+  `bin/chrome-listener.mjs` (chrome + post). Title "Momabobasheep",
+  hashtag-only description. Thumbnail = the lily-pad dream frame.
 - **Engine:** `pop/momboba/bin/render-momabobasheep.mjs` — a **generative**
   renderer (deterministic per `--seed`; the default seed string remains
   `mombobasleep`, the PRNG key for this exact walk). **C ENGINE

--- a/pop/momboba/momabobasheep.youtube.txt
+++ b/pop/momboba/momabobasheep.youtube.txt
@@ -1,0 +1,4 @@
+🎧 Spotify · https://open.spotify.com/album/1Hi0BG97U3aD4zW0Rmcabv
+ Apple Music · https://music.apple.com/us/album/momabobasheep-single-ep/6779669836
+
+#lullaby #sleep #ambient #marimba #felt #stopmotion #visualizer #aestheticcomputer #pixsies

--- a/toolchain/art-to-braille.mjs
+++ b/toolchain/art-to-braille.mjs
@@ -1,0 +1,122 @@
+// art-to-braille.mjs — draw ANYTHING inline as Unicode braille (no deps, no files).
+//
+// The only route that actually renders arbitrary art inline on GitHub: pack a
+// boolean dot-field into braille glyphs (U+2800, 2 wide x 4 tall dots per char)
+// and drop the text in a ``` code fence. No MathJax (\rule is unsupported), no
+// committed image.
+//
+//   node art-to-braille.mjs smiley
+//   node art-to-braille.mjs flower
+//   node art-to-braille.mjs image path/to/pic.png [cols] [--invert]
+//
+// image mode shells out to macOS `sips` to normalize+resize any input to an
+// 8-bit PNG, then decodes it with Node's built-in zlib (no image library).
+
+import { execFileSync } from "node:child_process";
+import { inflateSync } from "node:zlib";
+import { readFileSync } from "node:fs";
+
+// (col 0..1, row 0..3) -> braille dot bit
+const DOTBIT = { "0,0": 0x01, "0,1": 0x02, "0,2": 0x04, "1,0": 0x08, "1,1": 0x10, "1,2": 0x20, "0,3": 0x40, "1,3": 0x80 };
+
+function render(cols, rows, on) {
+  let out = "";
+  for (let cy = 0; cy < rows; cy++) {
+    for (let cx = 0; cx < cols; cx++) {
+      let code = 0;
+      for (let r = 0; r < 4; r++)
+        for (let c = 0; c < 2; c++)
+          if (on(cx * 2 + c, cy * 4 + r)) code |= DOTBIT[`${c},${r}`];
+      out += String.fromCharCode(0x2800 + code);
+    }
+    out += "\n";
+  }
+  return out;
+}
+
+// ---- parametric shapes (normalized -1..1 field) ----
+function shapeField(name, W, H) {
+  return (px, py) => {
+    const dx = (px / W - 0.5) * 2, dy = (py / H - 0.5) * 2;
+    if (name === "smiley") {
+      const ring = Math.abs(Math.hypot(dx, dy) - 0.85) < 0.06;
+      const eyeL = Math.hypot(dx + 0.35, dy + 0.3) < 0.1;
+      const eyeR = Math.hypot(dx - 0.35, dy + 0.3) < 0.1;
+      const smile = dy > 0.1 && Math.abs(Math.hypot(dx, dy - 0.1) - 0.45) < 0.06;
+      return ring || eyeL || eyeR || smile;
+    }
+    if (name === "flower") {
+      const a = Math.atan2(dy, dx), r = Math.hypot(dx, dy);
+      const petal = r < 0.78 * Math.abs(Math.cos(3 * a)) + 0.18; // rose curve
+      const core = r < 0.16;
+      return petal || core;
+    }
+    return Math.hypot(dx, dy) < 0.85; // circle
+  };
+}
+
+// ---- minimal PNG decode (8-bit, color types 0/2/4/6, no interlace) ----
+function decodePng(buf) {
+  let p = 8; // skip signature
+  let w, h, ct, idat = [];
+  while (p < buf.length) {
+    const len = buf.readUInt32BE(p); const type = buf.toString("ascii", p + 4, p + 8);
+    const data = buf.subarray(p + 8, p + 8 + len);
+    if (type === "IHDR") { w = data.readUInt32BE(0); h = data.readUInt32BE(4); ct = data[9]; }
+    else if (type === "IDAT") idat.push(data);
+    else if (type === "IEND") break;
+    p += 12 + len;
+  }
+  const ch = { 0: 1, 2: 3, 4: 2, 6: 4 }[ct];
+  if (!ch) throw new Error("unsupported PNG color type " + ct);
+  const raw = inflateSync(Buffer.concat(idat));
+  const stride = w * ch;
+  const out = Buffer.alloc(h * stride);
+  const pae = (a, b, c) => { const pp = a + b - c, da = Math.abs(pp - a), db = Math.abs(pp - b), dc = Math.abs(pp - c); return da <= db && da <= dc ? a : db <= dc ? b : c; };
+  let q = 0;
+  for (let y = 0; y < h; y++) {
+    const f = raw[q++];
+    for (let i = 0; i < stride; i++) {
+      const x = raw[q++];
+      const a = i >= ch ? out[y * stride + i - ch] : 0;
+      const b = y > 0 ? out[(y - 1) * stride + i] : 0;
+      const c = i >= ch && y > 0 ? out[(y - 1) * stride + i - ch] : 0;
+      let v = x;
+      if (f === 1) v = x + a; else if (f === 2) v = x + b; else if (f === 3) v = x + ((a + b) >> 1); else if (f === 4) v = x + pae(a, b, c);
+      out[y * stride + i] = v & 0xff;
+    }
+  }
+  return { w, h, ch, px: out };
+}
+
+function imageField(path, dotW, invert) {
+  const tmp = "/tmp/braille-norm.png";
+  execFileSync("sips", ["-s", "format", "png", "--resampleWidth", String(dotW), path, "-o", tmp], { stdio: "ignore" });
+  const { w, h, ch, px } = decodePng(readFileSync(tmp));
+  return {
+    W: w, H: h,
+    on: (x, y) => {
+      if (x >= w || y >= h) return false;
+      const o = (y * w + x) * ch;
+      const lum = ch >= 3 ? 0.299 * px[o] + 0.587 * px[o + 1] + 0.114 * px[o + 2] : px[o];
+      const dark = lum < 128;
+      return invert ? !dark : dark;
+    },
+  };
+}
+
+// ---- main ----
+const mode = process.argv[2] || "smiley";
+let cols, rows, on;
+if (mode === "image") {
+  const path = process.argv[3];
+  cols = parseInt(process.argv[4] || "50", 10);
+  const invert = process.argv.includes("--invert");
+  const f = imageField(path, cols * 2, invert);
+  cols = Math.ceil(f.W / 2); rows = Math.ceil(f.H / 4); on = f.on;
+} else {
+  cols = 40; rows = 16;
+  const W = cols * 2, H = rows * 4;
+  on = shapeField(mode, W, H);
+}
+process.stdout.write(render(cols, rows, on));


### PR DESCRIPTION
Promotes the inline-graphics findings from the sandbox demo (#25) into a permanent craft guide: **`GRAPHICS.md`** at the repo root, the third companion to `HAND.md` (how code reads) and `papers/VOICE.md` (how papers sound) — this one governs **how a PR or doc draws**.

### What's here
- **`GRAPHICS.md`** — written in the house voice. The one rule (sanitizer boundary), the verified ✅ palette (mermaid diagrams+charts, math, geojson, braille), the ❌ matrix with causes (`\rule` is text-mode → unsupported; `\colorbox` broken on GitHub since 2023; `array` `@{}` parse-errors), the named trap (web's `\rule` examples are native-LaTeX→PNG), the braille method for arbitrary art, a decision tree, and the papers/xelatex caveat.
- **`toolchain/art-to-braille.mjs`** — the working generator: parametric shapes (`smiley`/`flower`) + `image pic.png` → braille (Node `zlib` decode, `sips` normalize). The one route that draws arbitrary art inline.
- **`HAND.md`** — cross-linked to the new companion.

Every claim was probed live on github.com (see #25). Unlike #25 (sandbox), **this one is meant to merge.**
